### PR TITLE
Don't pass extraneous argument to sprintf()

### DIFF
--- a/src/osdep/unix/mh.c
+++ b/src/osdep/unix/mh.c
@@ -934,7 +934,7 @@ long mh_ping (MAILSTREAM *stream)
 	    unlink (LOCAL->buf);/* flush this file */
 	  }
 	  sprintf (tmp,"Message copy to MH mailbox failed: %.80s",
-		   s,strerror (errno));
+		   strerror (errno));
 	  mm_log (tmp,ERROR);
 	  r = 0;		/* stop the snarf in its tracks */
 	}


### PR DESCRIPTION
Only show the error description, not the chunk of whichever text we failed to
write to file, in the error message given when copying to MH mailbox failed.
